### PR TITLE
Add example to create Sentry releases.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+function_examples/sentry_releases/functions

--- a/function_examples/sentry_releases/Makefile
+++ b/function_examples/sentry_releases/Makefile
@@ -1,0 +1,4 @@
+build-functions:
+	mkdir -p functions
+	go get -v ./...
+	go build -o functions/deploy-succeeded cmd/deploy-succeeded/main.go

--- a/function_examples/sentry_releases/README.md
+++ b/function_examples/sentry_releases/README.md
@@ -1,0 +1,19 @@
+# Sentry release example
+
+This is an example of using [Netlify Functions](https://www.netlify.com/docs/functions/) to create a release in Sentry every time Netlify publishes a new Production deploy.
+
+## Configuration
+
+When you deploy your site to Netlify, you'll need to define the following [build environment variables](https://www.netlify.com/docs/continuous-deployment/#build-environment-variables) in the UI.
+
+1- Authentication token to talk with Sentry's API:
+
+* `SENTRY_AUTH_TOKEN` = "secret token issued by sentry"
+
+2- Your Sentry's organization slug:
+
+* `SENTRY_ORG_SLUG` = "netlify"
+
+3- Your Sentry's project slug:
+
+* `SENTRY_PROJECT_SLUG` = "code-examples"

--- a/function_examples/sentry_releases/cmd/deploy-succeeded/main.go
+++ b/function_examples/sentry_releases/cmd/deploy-succeeded/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+
+	sentry "github.com/atlassian/go-sentry-api"
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+type deploy struct {
+	CommitRef string `json:"commit_ref"`
+	Context   string `json:"context"`
+}
+
+func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	var d deploy
+
+	if err := json.NewDecoder(bytes.NewReader([]byte(request.Body))).Decode(&d); err != nil {
+		return events.APIGatewayProxyResponse{
+			StatusCode: 500,
+			Body:       err.Error(),
+		}, nil
+	}
+
+	if d.Context != "production" {
+		// Ignore deploys that don't go to production
+		return events.APIGatewayProxyResponse{
+			StatusCode: 200,
+			Body:       "I ran after a deploy was created",
+		}, nil
+	}
+
+	c, err := sentry.NewClient(os.Getenv("SENTRY_AUTH_TOKEN"), nil, nil)
+	if err != nil {
+		return events.APIGatewayProxyResponse{
+			StatusCode: 500,
+			Body:       err.Error(),
+		}, nil
+	}
+
+	orgSlug := os.Getenv("SENTRY_ORG_SLUG")
+	org := sentry.Organization{
+		Slug: &orgSlug,
+	}
+
+	proSlug := os.Getenv("SENTRY_PROJECT_SLUG")
+	pro := sentry.Project{
+		Slug: &proSlug,
+	}
+
+	rel := sentry.NewRelease{
+		Version: d.CommitRef,
+		Ref:     &d.CommitRef,
+	}
+
+	if _, err := c.CreateRelease(org, pro, rel); err != nil {
+		return events.APIGatewayProxyResponse{
+			StatusCode: 500,
+			Body:       err.Error(),
+		}, nil
+	}
+
+	return events.APIGatewayProxyResponse{
+		StatusCode: 200,
+		Body:       "I ran after a deploy was created",
+	}, nil
+}
+
+func main() {
+	// Make the handler available for Remote Procedure Call by AWS Lambda
+	lambda.Start(handler)
+}

--- a/function_examples/sentry_releases/netlify.toml
+++ b/function_examples/sentry_releases/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  functions = "functions"
+  publish = "site"
+  command = "make build-functions"
+
+[build.environment]
+  # change this value, you can set it in Netlify's UI too
+  GO_IMPORT_PATH = "github.com/netlify/code-examples"

--- a/function_examples/sentry_releases/site/index.html
+++ b/function_examples/sentry_releases/site/index.html
@@ -1,0 +1,6 @@
+<html>
+  <body>
+    <h1>Example of function creating Sentry releases</h1>
+    <p>This project includes a function that's triggered after each deploy. It creates a new release in Sentry if the deploy context is production. It ignores deploy previews and branch deploys, but it could be easier to modify to not do that</p>
+  </body>
+ </html>


### PR DESCRIPTION
- Create a new release each time Netlify publishes a new Production Deploy.

Signed-off-by: David Calavera <david.calavera@gmail.com>